### PR TITLE
tick counter

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,4 @@ cc = "1.0.28"
 
 [dependencies]
 #cortex-m-semihosting = "0.3.2"
-#cortex-m = "0.5.8"
+cortex-m = "0.5.8"


### PR DESCRIPTION
The first 2 commits are not required, as they're equal what I had.

Take a look at this patch. I'm not sure. As the library implements SysTick call, it's impossible to use standard delays. So I've added a 64-bit value which accumulates 32-bit CPU tick counter.

There is also a couple of macros on top of it to get monotonic timer and perform delays, however they need to know the timer frequency. I don't think it's a good idea to create own clock source object and etc. Can we leave it just simple as it is now and provide users a couple of examples in readme?

here are the examples:

```rust
macro_rules! get_monotonic {
    () => {
        get_counter() / TIMER_FREQ as u64
    };
}

macro_rules! delay_micros {
    ($dur:expr) => {
        let sleep_to = get_counter() + $dur * TIMER_FREQ as u64;
        while get_counter() < sleep_to {
            sleep(1);
        }
    };
}

macro_rules! delay_millis {
    ($dur:expr) => {
        delay_micros!($dur * 1_000);
    };
}

macro_rules! delay_s {
    ($dur:expr) => {
        delay_micros!($dur * 1_000_000);
    };
}
```